### PR TITLE
feat(#2,#3,#4,#5): define initial domain model foundation

### DIFF
--- a/shiftmanager/DOMAIN_MODEL.md
+++ b/shiftmanager/DOMAIN_MODEL.md
@@ -1,0 +1,48 @@
+# Initial Domain Model
+
+This document describes the initial backend domain model.
+
+## Models
+
+### User
+- `id`: unique identifier
+- `username`: unique username
+- `email`: unique email
+- `passwordHash`: hashed password
+- `active`: account status
+
+### Guard
+- `id`: unique identifier
+- `firstName`: guard first name
+- `lastName`: guard last name
+- `dni`: unique national identification document
+- `phone`: contact phone
+- `active`: guard status
+
+### Service
+- `id`: unique identifier
+- `name`: service name
+- `location`: physical location
+- `description`: service details
+- `active`: service status
+
+### ShiftAssignment
+- `id`: unique identifier
+- `guard`: assigned guard
+- `service`: assigned service
+- `date`: assignment date
+- `startTime`: shift start time
+- `endTime`: shift end time
+- `totalHours`: total worked hours for the shift
+- `notes`: optional notes
+
+## Relationships
+
+- One `Guard` can have many `ShiftAssignment` records.
+- One `Service` can have many `ShiftAssignment` records.
+- Each `ShiftAssignment` belongs to exactly one `Guard`.
+- Each `ShiftAssignment` belongs to exactly one `Service`.
+
+## Naming
+
+- All model names and fields are in English.

--- a/shiftmanager/build.gradle
+++ b/shiftmanager/build.gradle
@@ -19,6 +19,8 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	runtimeOnly 'com.h2database:h2'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/shiftmanager/src/main/java/com/security/shiftmanager/model/Guard.java
+++ b/shiftmanager/src/main/java/com/security/shiftmanager/model/Guard.java
@@ -1,0 +1,92 @@
+package com.security.shiftmanager.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "guards")
+public class Guard {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String firstName;
+
+    @Column(nullable = false)
+    private String lastName;
+
+    @Column(nullable = false, unique = true)
+    private String dni;
+
+    @Column(nullable = false)
+    private String phone;
+
+    @Column(nullable = false)
+    private boolean active;
+
+    public Guard() {
+    }
+
+    public Guard(Long id, String firstName, String lastName, String dni, String phone, boolean active) {
+        this.id = id;
+        this.firstName = firstName;
+        this.lastName = lastName;
+        this.dni = dni;
+        this.phone = phone;
+        this.active = active;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getFirstName() {
+        return firstName;
+    }
+
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    public String getLastName() {
+        return lastName;
+    }
+
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+
+    public String getDni() {
+        return dni;
+    }
+
+    public void setDni(String dni) {
+        this.dni = dni;
+    }
+
+    public String getPhone() {
+        return phone;
+    }
+
+    public void setPhone(String phone) {
+        this.phone = phone;
+    }
+
+    public boolean isActive() {
+        return active;
+    }
+
+    public void setActive(boolean active) {
+        this.active = active;
+    }
+}

--- a/shiftmanager/src/main/java/com/security/shiftmanager/model/Service.java
+++ b/shiftmanager/src/main/java/com/security/shiftmanager/model/Service.java
@@ -1,0 +1,80 @@
+package com.security.shiftmanager.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "services")
+public class Service {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false)
+    private String location;
+
+    @Column(nullable = false)
+    private String description;
+
+    @Column(nullable = false)
+    private boolean active;
+
+    public Service() {
+    }
+
+    public Service(Long id, String name, String location, String description, boolean active) {
+        this.id = id;
+        this.name = name;
+        this.location = location;
+        this.description = description;
+        this.active = active;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getLocation() {
+        return location;
+    }
+
+    public void setLocation(String location) {
+        this.location = location;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public boolean isActive() {
+        return active;
+    }
+
+    public void setActive(boolean active) {
+        this.active = active;
+    }
+}

--- a/shiftmanager/src/main/java/com/security/shiftmanager/model/ShiftAssignment.java
+++ b/shiftmanager/src/main/java/com/security/shiftmanager/model/ShiftAssignment.java
@@ -1,0 +1,133 @@
+package com.security.shiftmanager.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Entity
+@Table(name = "shift_assignments")
+public class ShiftAssignment {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "guard_id", nullable = false)
+    private Guard guard;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "service_id", nullable = false)
+    private Service service;
+
+    @Column(nullable = false)
+    private LocalDate date;
+
+    @Column(nullable = false)
+    private LocalTime startTime;
+
+    @Column(nullable = false)
+    private LocalTime endTime;
+
+    @Column(nullable = false, precision = 5, scale = 2)
+    private BigDecimal totalHours;
+
+    @Column(length = 500)
+    private String notes;
+
+    public ShiftAssignment() {
+    }
+
+    public ShiftAssignment(
+            Long id,
+            Guard guard,
+            Service service,
+            LocalDate date,
+            LocalTime startTime,
+            LocalTime endTime,
+            BigDecimal totalHours,
+            String notes
+    ) {
+        this.id = id;
+        this.guard = guard;
+        this.service = service;
+        this.date = date;
+        this.startTime = startTime;
+        this.endTime = endTime;
+        this.totalHours = totalHours;
+        this.notes = notes;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Guard getGuard() {
+        return guard;
+    }
+
+    public void setGuard(Guard guard) {
+        this.guard = guard;
+    }
+
+    public Service getService() {
+        return service;
+    }
+
+    public void setService(Service service) {
+        this.service = service;
+    }
+
+    public LocalDate getDate() {
+        return date;
+    }
+
+    public void setDate(LocalDate date) {
+        this.date = date;
+    }
+
+    public LocalTime getStartTime() {
+        return startTime;
+    }
+
+    public void setStartTime(LocalTime startTime) {
+        this.startTime = startTime;
+    }
+
+    public LocalTime getEndTime() {
+        return endTime;
+    }
+
+    public void setEndTime(LocalTime endTime) {
+        this.endTime = endTime;
+    }
+
+    public BigDecimal getTotalHours() {
+        return totalHours;
+    }
+
+    public void setTotalHours(BigDecimal totalHours) {
+        this.totalHours = totalHours;
+    }
+
+    public String getNotes() {
+        return notes;
+    }
+
+    public void setNotes(String notes) {
+        this.notes = notes;
+    }
+}

--- a/shiftmanager/src/main/java/com/security/shiftmanager/model/User.java
+++ b/shiftmanager/src/main/java/com/security/shiftmanager/model/User.java
@@ -1,0 +1,80 @@
+package com.security.shiftmanager.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "users")
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String username;
+
+    @Column(nullable = false, unique = true)
+    private String email;
+
+    @Column(nullable = false)
+    private String passwordHash;
+
+    @Column(nullable = false)
+    private boolean active;
+
+    public User() {
+    }
+
+    public User(Long id, String username, String email, String passwordHash, boolean active) {
+        this.id = id;
+        this.username = username;
+        this.email = email;
+        this.passwordHash = passwordHash;
+        this.active = active;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getPasswordHash() {
+        return passwordHash;
+    }
+
+    public void setPasswordHash(String passwordHash) {
+        this.passwordHash = passwordHash;
+    }
+
+    public boolean isActive() {
+        return active;
+    }
+
+    public void setActive(boolean active) {
+        this.active = active;
+    }
+}

--- a/shiftmanager/src/main/resources/application.properties
+++ b/shiftmanager/src/main/resources/application.properties
@@ -1,1 +1,7 @@
 spring.application.name=shiftmanager
+spring.datasource.url=jdbc:h2:mem:shiftmanager;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.show-sql=true


### PR DESCRIPTION
## Summary
- define initial domain model documentation for User, Guard, Service, and ShiftAssignment
- add JPA entities for User, Guard, Service, and ShiftAssignment with core relationships
- configure JPA + H2 in-memory datasource to support persistence work in upcoming issues

## Test plan
- [x] Run ./gradlew test
- [x] Verify application compiles with JPA entities

## Linked issues
Closes #2
Closes #3
Closes #4
Closes #5